### PR TITLE
Fixed the look up table for 2082BS

### DIFF
--- a/src/main/java/np/com/bahadur/converter/date/nepali/DateConverter.java
+++ b/src/main/java/np/com/bahadur/converter/date/nepali/DateConverter.java
@@ -93,7 +93,7 @@ public class DateConverter {
      * @param adDate english date format string "dd-MM-yyyy"
      * @return Bikram Sambat date - String type yyyy-MM-dd. There would be 1 digit month and day of month.
      */
-    String convertAdToBs(String adDate) throws ParseException {
+    public String convertAdToBs(String adDate) throws ParseException {
         String[] adDateParts = adDate.split("-");
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");

--- a/src/main/java/np/com/bahadur/converter/date/nepali/Lookup.java
+++ b/src/main/java/np/com/bahadur/converter/date/nepali/Lookup.java
@@ -403,7 +403,7 @@ public class Lookup {
                 30, 30});// 2080
         numberOfDaysInNepaliMonth.put(2081, new Byte[]{31, 31, 32, 32, 31, 30, 30, 30, 29, 30,
                 30, 31});// 2081
-        numberOfDaysInNepaliMonth.put(2082, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2082, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 2082
         numberOfDaysInNepaliMonth.put(2083, new Byte[]{31, 31, 32, 31, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2083

--- a/src/test/java/np/com/bahadur/converter/date/nepali/DateConverterTest.java
+++ b/src/test/java/np/com/bahadur/converter/date/nepali/DateConverterTest.java
@@ -1,5 +1,7 @@
 package np.com.bahadur.converter.date.nepali;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,5 +157,28 @@ class DateConverterTest {
 
     }
 
+
+    @Nested
+    @DisplayName("Testing for 2082BS")
+    class TestFor2082BS {
+        @Test
+        @DisplayName("English date conversion should return the specified nepali dates which are based from a physical calendar")
+        void testFor2082() throws ParseException {
+            assertEquals("2082-1-16", dc.convertAdToBs("29-04-2025"));
+            assertEquals("2082-2-16", dc.convertAdToBs("30-05-2025"));
+            assertEquals("2082-3-16", dc.convertAdToBs("30-06-2025"));
+            assertEquals("2082-4-16", dc.convertAdToBs("01-08-2025"));
+            assertEquals("2082-4-16", dc.convertAdToBs("01-08-2025"));
+            assertEquals("2082-5-16", dc.convertAdToBs("01-09-2025"));
+            assertEquals("2082-6-16", dc.convertAdToBs("02-10-2025"));
+            assertEquals("2082-7-16", dc.convertAdToBs("02-11-2025"));
+            assertEquals("2082-8-16", dc.convertAdToBs("02-12-2025"));
+            assertEquals("2082-9-16", dc.convertAdToBs("31-12-2025"));
+            assertEquals("2082-10-16", dc.convertAdToBs("30-01-2026"));
+            assertEquals("2082-11-16", dc.convertAdToBs("28-02-2026"));
+            assertEquals("2082-12-16", dc.convertAdToBs("30-03-2026"));
+        }
+
+    }
 
 }


### PR DESCRIPTION
- the english to nepali date conversion for 2082BS was wrong due to incorrect look up table. Corrected the look up table from a physical calendar

- added unit tests to verify that the conversion for 2082BS was indeed correct with 13 assertions. 

- the convertAdToBs() was scoped as 'default'. Changed that to public so that the function becomes available to all outside classes. 

