### PR TITLE
Fix corrupted Bikram Sambat month-length and anchor tables

### DIFF
--- a/src/main/java/np/com/bahadur/converter/date/nepali/Lookup.java
+++ b/src/main/java/np/com/bahadur/converter/date/nepali/Lookup.java
@@ -46,7 +46,7 @@ public class Lookup {
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1915");
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1916");
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1917");
-        adEquivalentDatesForNewNepaliYear.add("12-Apr-1918");
+        adEquivalentDatesForNewNepaliYear.add("13-Apr-1918");
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1919");
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1920");
         adEquivalentDatesForNewNepaliYear.add("13-Apr-1921");
@@ -163,7 +163,7 @@ public class Lookup {
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2032");// 2089
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2033");// 2090
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2034");// 2091
-        adEquivalentDatesForNewNepaliYear.add("13-Apr-2035");// 2092
+        adEquivalentDatesForNewNepaliYear.add("15-Apr-2035");// 2092
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2036");// 2093
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2037");// 2094
         adEquivalentDatesForNewNepaliYear.add("14-Apr-2038");// 2095
@@ -189,17 +189,17 @@ public class Lookup {
                 29, 31});// 1973
         numberOfDaysInNepaliMonth.put(1974, new Byte[]{31, 31, 32, 30, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1974
-        numberOfDaysInNepaliMonth.put(1975, new Byte[]{31, 31, 32, 32, 30, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1975, new Byte[]{31, 31, 32, 32, 31, 30, 30, 29, 30, 29,
                 30, 30});// 1975
         numberOfDaysInNepaliMonth.put(1976, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 31});// 1976
-        numberOfDaysInNepaliMonth.put(1977, new Byte[]{30, 32, 31, 32, 31, 31, 29, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(1977, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 29, 31});// 1977
         numberOfDaysInNepaliMonth.put(1978, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1978
         numberOfDaysInNepaliMonth.put(1979, new Byte[]{31, 31, 32, 32, 31, 30, 30, 29, 30, 29,
                 30, 30});// 1979
-        numberOfDaysInNepaliMonth.put(1980, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 29,
+        numberOfDaysInNepaliMonth.put(1980, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 31});// 1980
         numberOfDaysInNepaliMonth.put(1981, new Byte[]{31, 31, 31, 32, 31, 31, 29, 30, 30, 29,
                 30, 30});// 1981
@@ -217,29 +217,29 @@ public class Lookup {
                 30, 30});// 1987
         numberOfDaysInNepaliMonth.put(1988, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 31});// 1988
-        numberOfDaysInNepaliMonth.put(1989, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1989, new Byte[]{31, 31, 31, 32, 31, 31, 29, 30, 30, 29,
                 30, 30});// 1989
-        numberOfDaysInNepaliMonth.put(1990, new Byte[]{30, 31, 32, 31, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1990, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1990
-        numberOfDaysInNepaliMonth.put(1991, new Byte[]{31, 32, 31, 32, 31, 30, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1991, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 30});// 1991
         numberOfDaysInNepaliMonth.put(1992, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
-                29, 30});// 1992
-        numberOfDaysInNepaliMonth.put(1993, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+                29, 31});// 1992
+        numberOfDaysInNepaliMonth.put(1993, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1993
-        numberOfDaysInNepaliMonth.put(1994, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1994, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1994
-        numberOfDaysInNepaliMonth.put(1995, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1995, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 30});// 1995
-        numberOfDaysInNepaliMonth.put(1996, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
-                30, 30});// 1996
-        numberOfDaysInNepaliMonth.put(1997, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1996, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+                29, 31});// 1996
+        numberOfDaysInNepaliMonth.put(1997, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1997
-        numberOfDaysInNepaliMonth.put(1998, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
+        numberOfDaysInNepaliMonth.put(1998, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 1998
-        numberOfDaysInNepaliMonth.put(1999, new Byte[]{31, 31, 31, 32, 31, 31, 30, 29, 30, 29,
-                30, 30});// 1999
-        numberOfDaysInNepaliMonth.put(2000, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
+        numberOfDaysInNepaliMonth.put(1999, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
+                30, 31});// 1999
+        numberOfDaysInNepaliMonth.put(2000, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 29, 31});// 2000
         numberOfDaysInNepaliMonth.put(2001, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 2001
@@ -363,7 +363,7 @@ public class Lookup {
                 30, 30});// 2060
         numberOfDaysInNepaliMonth.put(2061, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 31});
-        numberOfDaysInNepaliMonth.put(2062, new Byte[]{30, 32, 31, 32, 31, 31, 29, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2062, new Byte[]{31, 31, 31, 32, 31, 31, 29, 30, 29, 30,
                 29, 31});
         numberOfDaysInNepaliMonth.put(2063, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});
@@ -401,31 +401,31 @@ public class Lookup {
                 30, 30});
         numberOfDaysInNepaliMonth.put(2080, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 29,
                 30, 30});// 2080
-        numberOfDaysInNepaliMonth.put(2081, new Byte[]{31, 31, 32, 32, 31, 30, 30, 30, 29, 30,
-                30, 31});// 2081
+        numberOfDaysInNepaliMonth.put(2081, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+                29, 31});// 2081
         numberOfDaysInNepaliMonth.put(2082, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 2082
-        numberOfDaysInNepaliMonth.put(2083, new Byte[]{31, 31, 32, 31, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2083, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 29,
                 30, 30});// 2083
         numberOfDaysInNepaliMonth.put(2084, new Byte[]{31, 31, 32, 31, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2084
-        numberOfDaysInNepaliMonth.put(2085, new Byte[]{31, 32, 31, 32, 31, 31, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2085, new Byte[]{31, 32, 31, 32, 30, 31, 30, 30, 29, 30,
                 30, 30});// 2085
-        numberOfDaysInNepaliMonth.put(2086, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2086, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2086
-        numberOfDaysInNepaliMonth.put(2087, new Byte[]{31, 31, 32, 31, 31, 31, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2087, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 30, 30,
                 30, 30});// 2087
         numberOfDaysInNepaliMonth.put(2088, new Byte[]{30, 31, 32, 32, 30, 31, 30, 30, 29, 30,
                 30, 30});// 2088
-        numberOfDaysInNepaliMonth.put(2089, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2089, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2089
-        numberOfDaysInNepaliMonth.put(2090, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2090, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2090
         numberOfDaysInNepaliMonth.put(2091, new Byte[]{31, 31, 32, 31, 31, 31, 30, 30, 29, 30,
                 30, 30});// 2091
-        numberOfDaysInNepaliMonth.put(2092, new Byte[]{31, 31, 32, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2092, new Byte[]{30, 31, 32, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2092
-        numberOfDaysInNepaliMonth.put(2093, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
+        numberOfDaysInNepaliMonth.put(2093, new Byte[]{30, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2093
         numberOfDaysInNepaliMonth.put(2094, new Byte[]{31, 31, 32, 31, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2094
@@ -436,7 +436,7 @@ public class Lookup {
         numberOfDaysInNepaliMonth.put(2097, new Byte[]{31, 32, 31, 32, 31, 30, 30, 30, 29, 30,
                 30, 30});// 2097
         numberOfDaysInNepaliMonth.put(2098, new Byte[]{31, 31, 32, 31, 31, 31, 29, 30, 29, 30,
-                30, 31});// 2098
+                29, 31});// 2098
         numberOfDaysInNepaliMonth.put(2099, new Byte[]{31, 31, 32, 31, 31, 31, 30, 29, 29, 30,
                 30, 30});// 2099
         numberOfDaysInNepaliMonth.put(2100, new Byte[]{31, 32, 31, 32, 30, 31, 30, 29, 30, 29,

--- a/src/test/java/np/com/bahadur/converter/date/nepali/DateConverterTest.java
+++ b/src/test/java/np/com/bahadur/converter/date/nepali/DateConverterTest.java
@@ -39,6 +39,87 @@ class DateConverterTest {
 
     }
 
+    /**
+     * Regression test for corrupted Bikram Sambat month-length and AD-new-year
+     * anchor tables in {@link Lookup}.
+     * <p>
+     * Each case below was previously RED (off by -2/-1/+1 days) because the
+     * hardcoded {@code numberOfDaysInNepaliMonth} table had transcription
+     * errors in 26 BS years and {@code adEquivalentDatesForNewNepaliYear} had
+     * 2 wrong anchors (BS1975, BS2092). The expected AD dates are the official
+     * Nepal Calendar Committee values (as shipped by the {@code nepali_datetime}
+     * 1.0.8.5 Python package). Before the table fix these assertions failed;
+     * after the fix they must pass.
+     */
+    @Test
+    void testBsToAdOfficialCalendarRegression() {
+        Calendar c = Calendar.getInstance();
+
+        // BS 2085-06-01 -> 2028-09-16 (was 2028-09-17, +1)
+        c.clear();
+        c.set(2028, Calendar.SEPTEMBER, 16);
+        assertEquals(c.getTime(), dc.convertBsToAd("01062085"));
+
+        // BS 2092-01-01 -> 2035-04-15 (was 2035-04-13, -2; anchor-table error)
+        c.clear();
+        c.set(2035, Calendar.APRIL, 15);
+        assertEquals(c.getTime(), dc.convertBsToAd("01012092"));
+
+        // BS 1975-06-01 -> 1918-09-17 (was 1918-09-15, -2; anchor-table error)
+        c.clear();
+        c.set(1918, Calendar.SEPTEMBER, 17);
+        assertEquals(c.getTime(), dc.convertBsToAd("01061975"));
+
+        // BS 1975-05-01 -> 1918-08-17 (was 1918-08-16, -1)
+        c.clear();
+        c.set(1918, Calendar.AUGUST, 17);
+        assertEquals(c.getTime(), dc.convertBsToAd("01051975"));
+
+        // BS 2081-12-01 -> 2025-03-14 (was 2025-03-15, +1)
+        c.clear();
+        c.set(2025, Calendar.MARCH, 14);
+        assertEquals(c.getTime(), dc.convertBsToAd("01122081"));
+
+        // BS 2086-02-01 -> 2029-05-14 (was 2029-05-15, +1)
+        c.clear();
+        c.set(2029, Calendar.MAY, 14);
+        assertEquals(c.getTime(), dc.convertBsToAd("01022086"));
+
+        // BS 2089-02-01 -> 2032-05-14 (was 2032-05-15, +1)
+        c.clear();
+        c.set(2032, Calendar.MAY, 14);
+        assertEquals(c.getTime(), dc.convertBsToAd("01022089"));
+
+        // BS 2098-12-01 -> 2042-03-14 (was 2042-03-15, +1)
+        c.clear();
+        c.set(2042, Calendar.MARCH, 14);
+        assertEquals(c.getTime(), dc.convertBsToAd("01122098"));
+
+        // Reality anchors that were already correct and must stay correct.
+        // BS 2081-01-01 -> 2024-04-13 (New Year 2081 BS, 2024-04-13).
+        c.clear();
+        c.set(2024, Calendar.APRIL, 13);
+        assertEquals(c.getTime(), dc.convertBsToAd("01012081"));
+
+        // BS 2079-01-01 -> 2022-04-14.
+        c.clear();
+        c.set(2022, Calendar.APRIL, 14);
+        assertEquals(c.getTime(), dc.convertBsToAd("01012079"));
+    }
+
+    /**
+     * Reverse-direction regression: AD -> BS for the previously-RED anchors.
+     */
+    @Test
+    void testAdToBsOfficialCalendarRegression() throws ParseException {
+        // 2028-09-16 -> BS 2085-6-1
+        assertEquals("2085-6-1", dc.convertAdToBs("16-09-2028"));
+        // 2035-04-15 -> BS 2092-1-1 (anchor-table error year)
+        assertEquals("2092-1-1", dc.convertAdToBs("15-04-2035"));
+        // 1918-09-17 -> BS 1975-6-1 (anchor-table error year)
+        assertEquals("1975-6-1", dc.convertAdToBs("17-09-1918"));
+    }
+
     @Test
     void testAdToBs() throws ParseException {
         //first argument nepali date, second english date 


### PR DESCRIPTION
## Problem

The hardcoded Bikram Sambat (BS) month-length table in `Lookup.java` is transcribed incorrectly for 26 BS years, and the AD-new-year anchor table has 2 wrong entries. As a result in-range BS<->AD conversions are silently off by +/-1 day (worst case -2 days at BS 2092), and the table is even self-inconsistent with the repo's own anchor table in 16 years (`D[Y+1]-D[Y] != sum(monthlen[Y])`).

## Evidence

Differential harness triangulated against the official Nepal Calendar Committee data via the `nepali_datetime` 1.0.8.5 package, the `medic/bikram-sambat` reference, internal consistency, and reality (e.g. BS 2081-01-01 = 2024-04-13). Exhaustive sweep over all 45,657 BS days: **4,167 RED (9.13%)**, offset histogram {-2: 60, -1: 2130, +1: 1977}. Concrete cases: BS 2085-06-01 -> 2028-09-17 (should be 2028-09-16, +1); BS 2092-01-01 -> 2035-04-13 (should be 2035-04-15, -2).

## Fix

Corrected the 26 `numberOfDaysInNepaliMonth` entries and the 2 `adEquivalentDatesForNewNepaliYear` anchors (BS 1975 -> 1918-04-13, BS 2092 -> 2035-04-15) to the official `nepali_datetime` values. Pure data-table correction, no logic change; surrounding code style preserved.

## Tests

`mvn test`: 16 passed, 0 failed. Added 2 JUnit regression tests (13 cases) covering the previously-RED cases. Pre-fix: the 2 new tests fail (expected 2028-09-16 but was 2028-09-17, etc.); post-fix: pass. Re-running the differential harness on the corrected table gives 0/45,657 day mismatches.

Out of scope: BS 1972 and BS 1974 are internally inconsistent but outside the official `nepali_datetime` range (1975-2100), so no canonical value exists; left untouched to keep the fix minimal and oracle-backed.